### PR TITLE
Add ability to define serializer for memoized values

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -16,6 +16,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
     - name: Lint
-      run: uv run pyright
+      run: uv run --all-extras pyright
     - name: Check type completeness
-      run: uv run pyright --ignoreexternal --verifytypes stickynote
+      run: uv run --all-extras pyright --ignoreexternal --verifytypes stickynote

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,5 +15,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
-    - name: Run tests
+    - name: Run tests with no extras
       run: uv run pytest
+    - name: Run tests with all extras
+      run: uv run --all-extras pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,13 @@ description = "Distributed function memoization"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
+    "exceptiongroup>=1.2.2",
+    "pytest-watcher>=0.4.3",
     "typing-extensions>=4.13.1",
 ]
+
+[project.optional-dependencies]
+cloudpickle = ["cloudpickle>=3.1.1"]
 
 [dependency-groups]
 dev = [

--- a/stickynote/memoize.py
+++ b/stickynote/memoize.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import base64
 from functools import partial
-import pickle
-from typing import Any, Callable, Literal, TypeVar, cast, overload
+from typing import Any, Callable, Iterable, Literal, TypeVar, cast, overload
 
 from typing_extensions import ParamSpec, Self
+from exceptiongroup import ExceptionGroup
 
 from stickynote.key_strategies import DEFAULT_STRATEGY, MemoKeyStrategy
+from stickynote.serializers import DEFAULT_SERIALIZER_CHAIN, Serializer
 from stickynote.storage import DEFAULT_STORAGE, MemoStorage
 
 P = ParamSpec("P")
@@ -26,6 +26,7 @@ def memoize(
     *,
     storage: MemoStorage = DEFAULT_STORAGE,
     key_strategy: MemoKeyStrategy = DEFAULT_STRATEGY,
+    serializer: Serializer | Iterable[Serializer] = DEFAULT_SERIALIZER_CHAIN,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
@@ -34,6 +35,7 @@ def memoize(
     *,
     storage: MemoStorage = DEFAULT_STORAGE,
     key_strategy: MemoKeyStrategy = DEFAULT_STRATEGY,
+    serializer: Serializer | Iterable[Serializer] = DEFAULT_SERIALIZER_CHAIN,
 ) -> Callable[[Callable[P, R]], Callable[P, R]] | Callable[P, R]:
     """
     Decorator to memoize the results of a function.
@@ -42,12 +44,17 @@ def memoize(
     if __fn is None:
         return cast(
             Callable[[Callable[P, R]], Callable[P, R]],
-            partial(memoize, storage=storage, key_strategy=key_strategy),
+            partial(
+                memoize,
+                storage=storage,
+                key_strategy=key_strategy,
+                serializer=serializer,
+            ),
         )
     else:
 
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            with MemoBlock(storage) as memo:
+            with MemoBlock(storage, serializer) as memo:
                 key = key_strategy.compute(__fn, args, kwargs)
                 memo.load(key)
                 if memo.hit:
@@ -64,10 +71,18 @@ class MemoBlock:
     Context manager to load and save the result of a function to a backend.
     """
 
-    def __init__(self, storage: MemoStorage = DEFAULT_STORAGE):
+    def __init__(
+        self,
+        storage: MemoStorage = DEFAULT_STORAGE,
+        serializer: Serializer | Iterable[Serializer] = DEFAULT_SERIALIZER_CHAIN,
+    ):
         self.storage = storage
         self.hit: bool = False
         self.value: Any = None
+        if isinstance(serializer, Iterable):
+            self.serializer: tuple[Serializer, ...] = tuple(serializer)
+        else:
+            self.serializer: tuple[Serializer, ...] = (serializer,)
 
     def __enter__(self) -> Self:
         return self
@@ -79,20 +94,35 @@ class MemoBlock:
         """
         Load the result of a function from the backend.
         """
+        serializer_exceptions: list[Exception] = []
         if self.storage.exists(key):
-            self.value = _deserialize_result(self.storage.get(key))
-            self.hit = True
+            for serializer in self.serializer:
+                try:
+                    self.value = serializer.deserialize(self.storage.get(key))
+                    self.hit = True
+                    break
+                except Exception as e:
+                    serializer_exceptions.append(e)
+
+        if len(serializer_exceptions) == len(self.serializer):
+            raise ExceptionGroup(
+                "All serializers failed to deserialize the result.",
+                serializer_exceptions,
+            )
 
     def save(self, key: str, value: Any) -> None:
         """
         Save the result of a function to the backend.
         """
-        self.storage.set(key, _serialize_result(value))
+        serializer_exceptions: list[Exception] = []
+        for serializer in self.serializer:
+            try:
+                self.storage.set(key, serializer.serialize(value))
+                break
+            except Exception as e:
+                serializer_exceptions.append(e)
 
-
-def _serialize_result(result: Any) -> str:
-    return base64.b64encode(pickle.dumps(result)).decode("utf-8")
-
-
-def _deserialize_result(serialized_result: str) -> Any:
-    return pickle.loads(base64.b64decode(serialized_result.encode("utf-8")))
+        if len(serializer_exceptions) == len(self.serializer):
+            raise ExceptionGroup(
+                "All serializers failed to serialize the result.", serializer_exceptions
+            )

--- a/stickynote/memoize.py
+++ b/stickynote/memoize.py
@@ -79,10 +79,10 @@ class MemoBlock:
         self.storage = storage
         self.hit: bool = False
         self.value: Any = None
-        if isinstance(serializer, Iterable):
-            self.serializer: tuple[Serializer, ...] = tuple(serializer)
-        else:
+        if isinstance(serializer, Serializer):
             self.serializer: tuple[Serializer, ...] = (serializer,)
+        else:
+            self.serializer: tuple[Serializer, ...] = tuple(serializer)
 
     def __enter__(self) -> Self:
         return self

--- a/stickynote/serializers.py
+++ b/stickynote/serializers.py
@@ -1,0 +1,53 @@
+import base64
+import json
+import pickle
+from typing import Any, Protocol
+
+
+class Serializer(Protocol):
+    def serialize(self, obj: Any) -> str: ...
+
+    def deserialize(self, data: str) -> Any: ...
+
+
+class JsonSerializer(Serializer):
+    def serialize(self, obj: Any) -> str:
+        return json.dumps(obj)
+
+    def deserialize(self, data: str) -> Any:
+        return json.loads(data)
+
+
+class PickleSerializer(Serializer):
+    def serialize(self, obj: Any) -> str:
+        return base64.b64encode(pickle.dumps(obj)).decode("utf-8")
+
+    def deserialize(self, data: str) -> Any:
+        return pickle.loads(base64.b64decode(data.encode("utf-8")))
+
+
+class CloudPickleSerializer(Serializer):
+    def serialize(self, obj: Any) -> str:
+        try:
+            import cloudpickle  # pyright: ignore[reportMissingTypeStubs]
+        except ImportError:
+            raise ImportError(
+                "Unable to import cloudpickle. Please install 'stickynote[cloudpickle]' to use this serializer."
+            )
+        return base64.b64encode(cloudpickle.dumps(obj)).decode("utf-8")  # pyright: ignore[reportUnknownMemberType]
+
+    def deserialize(self, data: str) -> Any:
+        try:
+            import cloudpickle  # pyright: ignore[reportMissingTypeStubs]
+        except ImportError:
+            raise ImportError(
+                "Unable to import cloudpickle. Please install 'stickynote[cloudpickle]' to use this serializer."
+            )
+
+        return cloudpickle.loads(base64.b64decode(data.encode("utf-8")))
+
+
+DEFAULT_SERIALIZER_CHAIN: tuple[Serializer, ...] = (
+    JsonSerializer(),
+    PickleSerializer(),
+)

--- a/stickynote/serializers.py
+++ b/stickynote/serializers.py
@@ -1,9 +1,10 @@
 import base64
 import json
 import pickle
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 
+@runtime_checkable
 class Serializer(Protocol):
     def serialize(self, obj: Any) -> str: ...
 

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -481,7 +481,7 @@ class TestMemoBlock:
                 "test_key", closure_func
             )  # save something that pickle can't handle, but cloudpickle can
             assert storage.exists("test_key")
-            assert storage.get("test_key") == serializer[2].serialize(closure_func)
+            assert storage.get("test_key") == serializer[-1].serialize(closure_func)
 
     def test_all_serializers_fail(self):
         storage = MemoryStorage()

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -24,12 +24,7 @@ from stickynote.storage import MemoryStorage
 from exceptiongroup import ExceptionGroup
 
 # Test CloudPickleSerializer only if cloudpickle is available
-try:
-    importlib.util.find_spec("cloudpickle")
-
-    HAS_CLOUDPICKLE = True
-except ImportError:
-    HAS_CLOUDPICKLE = False  # pyright: ignore[reportConstantRedefinition]
+HAS_CLOUDPICKLE = importlib.util.find_spec("cloudpickle") is not None
 
 
 class TestMemoize:
@@ -341,6 +336,7 @@ class TestMemoize:
         assert result == 3
         assert call_count == 1
 
+    @pytest.mark.skipif(not HAS_CLOUDPICKLE, reason="cloudpickle not installed")
     def test_with_multiple_serializers(self):
         storage = MemoryStorage()
         serializer = (JsonSerializer(), PickleSerializer(), CloudPickleSerializer())

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import json
 import pickle
 from typing import Any, Callable, Dict
 import importlib.util
@@ -411,7 +410,7 @@ class TestMemoBlock:
         with MemoBlock(storage) as memo:
             memo.save(key, test_value)
             assert storage.exists(key)
-            assert storage.get(key) == json.dumps({"key": "value"})
+            assert storage.get(key) == JsonSerializer().serialize({"key": "value"})
 
     def test_save_and_load(self):
         storage = MemoryStorage()
@@ -457,9 +456,15 @@ class TestMemoBlock:
             assert storage.get("test_key") == serializer.serialize({"key": "value"})
 
     @pytest.mark.skipif(not HAS_CLOUDPICKLE, reason="cloudpickle not installed")
-    def test_with_multiple_serializers(self):
+    @pytest.mark.parametrize(
+        "serializer",
+        [
+            (JsonSerializer(), PickleSerializer(), CloudPickleSerializer()),
+            [JsonSerializer(), CloudPickleSerializer()],
+        ],
+    )
+    def test_with_multiple_serializers(self, serializer):
         storage = MemoryStorage()
-        serializer = (JsonSerializer(), PickleSerializer(), CloudPickleSerializer())
 
         def outer(x: int) -> Callable[[int], int]:
             y = x * 2

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import base64
+import json
 import pickle
-from typing import Any, Dict
+from typing import Any, Callable, Dict
+import importlib.util
+
+import pytest
 
 from stickynote import memoize
 from stickynote.key_strategies import (
@@ -11,7 +15,21 @@ from stickynote.key_strategies import (
     SourceCode,
 )
 from stickynote.memoize import MemoBlock
+from stickynote.serializers import (
+    CloudPickleSerializer,
+    JsonSerializer,
+    PickleSerializer,
+)
 from stickynote.storage import MemoryStorage
+from exceptiongroup import ExceptionGroup
+
+# Test CloudPickleSerializer only if cloudpickle is available
+try:
+    importlib.util.find_spec("cloudpickle")
+
+    HAS_CLOUDPICKLE = True
+except ImportError:
+    HAS_CLOUDPICKLE = False  # pyright: ignore[reportConstantRedefinition]
 
 
 class TestMemoize:
@@ -303,6 +321,65 @@ class TestMemoize:
         assert result3 == 1
         assert call_count == 2
 
+    def test_with_non_default_serializer(self):
+        storage = MemoryStorage()
+        serializer = JsonSerializer()
+
+        call_count = 0
+
+        @memoize(storage=storage, serializer=serializer)
+        def add(a: int, b: int) -> int:
+            nonlocal call_count
+            call_count += 1
+            return a + b
+
+        result = add(1, 2)
+        assert result == 3
+        assert call_count == 1
+
+        result = add(1, 2)
+        assert result == 3
+        assert call_count == 1
+
+    def test_with_multiple_serializers(self):
+        storage = MemoryStorage()
+        serializer = (JsonSerializer(), PickleSerializer(), CloudPickleSerializer())
+
+        call_count = 0
+
+        @memoize(storage=storage, serializer=serializer)
+        def add_factory(a: int, b: int) -> Callable[[], int]:
+            def add() -> int:
+                return a + b
+
+            nonlocal call_count
+            call_count += 1
+            return add
+
+        result = add_factory(1, 2)
+        assert result() == 3
+        assert call_count == 1
+
+        result = add_factory(1, 2)
+        assert result() == 3
+        assert call_count == 1
+
+    def test_all_serializers_fail(self):
+        storage = MemoryStorage()
+        serializer = (JsonSerializer(), PickleSerializer())
+
+        @memoize(storage=storage, serializer=serializer)
+        def add_factory(a: int, b: int) -> Callable[[], int]:
+            def add() -> int:
+                return a + b
+
+            return add
+
+        with pytest.raises(ExceptionGroup) as e:
+            add_factory(1, 2)
+
+        assert len(e.value.exceptions) == 2
+
 
 class TestMemoBlock:
     def test_context_manager(self):
@@ -338,9 +415,7 @@ class TestMemoBlock:
         with MemoBlock(storage) as memo:
             memo.save(key, test_value)
             assert storage.exists(key)
-            assert storage.get(key) == base64.b64encode(
-                pickle.dumps(test_value)
-            ).decode("utf-8")
+            assert storage.get(key) == json.dumps({"key": "value"})
 
     def test_save_and_load(self):
         storage = MemoryStorage()
@@ -376,3 +451,53 @@ class TestMemoBlock:
             memo.load(key)
             assert memo.hit
             assert memo.value == test_value
+
+    def test_with_non_default_serializer(self):
+        storage = MemoryStorage()
+        serializer = JsonSerializer()
+        with MemoBlock(storage, serializer) as memo:
+            memo.save("test_key", {"key": "value"})
+            assert storage.exists("test_key")
+            assert storage.get("test_key") == serializer.serialize({"key": "value"})
+
+    @pytest.mark.skipif(not HAS_CLOUDPICKLE, reason="cloudpickle not installed")
+    def test_with_multiple_serializers(self):
+        storage = MemoryStorage()
+        serializer = (JsonSerializer(), PickleSerializer(), CloudPickleSerializer())
+
+        def outer(x: int) -> Callable[[int], int]:
+            y = x * 2
+
+            def inner(z: int) -> int:
+                return y + z
+
+            return inner
+
+        closure_func = outer(5)
+
+        with MemoBlock(storage, serializer) as memo:
+            memo.save(
+                "test_key", closure_func
+            )  # save something that pickle can't handle, but cloudpickle can
+            assert storage.exists("test_key")
+            assert storage.get("test_key") == serializer[2].serialize(closure_func)
+
+    def test_all_serializers_fail(self):
+        storage = MemoryStorage()
+        serializer = (JsonSerializer(), PickleSerializer())
+
+        def outer(x: int) -> Callable[[int], int]:
+            y = x * 2
+
+            def inner(z: int) -> int:
+                return y + z
+
+            return inner
+
+        closure_func = outer(5)
+
+        with pytest.raises(ExceptionGroup) as e:
+            with MemoBlock(storage, serializer) as memo:
+                memo.save("test_key", closure_func)
+
+        assert len(e.value.exceptions) == 2

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.util
 import json
 import base64
@@ -81,12 +83,7 @@ def test_serializer_chain(test_data: Any):
 
 
 # Test CloudPickleSerializer only if cloudpickle is available
-try:
-    importlib.util.find_spec("cloudpickle")
-
-    HAS_CLOUDPICKLE = True
-except ImportError:
-    HAS_CLOUDPICKLE = False  # pyright: ignore[reportConstantRedefinition]
+HAS_CLOUDPICKLE = importlib.util.find_spec("cloudpickle") is not None
 
 
 @pytest.mark.skipif(not HAS_CLOUDPICKLE, reason="cloudpickle not installed")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,135 @@
+import importlib.util
+import json
+import base64
+from typing import Any, Callable
+import pytest
+
+from stickynote.serializers import (
+    JsonSerializer,
+    PickleSerializer,
+    CloudPickleSerializer,
+    DEFAULT_SERIALIZER_CHAIN,
+)
+
+
+def test_json_serializer():
+    serializer = JsonSerializer()
+
+    # Test with simple data types
+    test_data = {
+        "string": "hello",
+        "number": 42,
+        "boolean": True,
+        "list": [1, 2, 3],
+        "dict": {"a": 1, "b": 2},
+        "null": None,
+    }
+
+    serialized = serializer.serialize(test_data)
+    assert isinstance(serialized, str)
+    assert json.loads(serialized) == test_data
+
+    deserialized = serializer.deserialize(serialized)
+    assert deserialized == test_data
+
+
+def test_pickle_serializer():
+    serializer = PickleSerializer()
+
+    # Test with Python objects
+    test_data = {
+        "string": "hello",
+        "number": 42,
+        "boolean": True,
+        "list": [1, 2, 3],
+        "dict": {"a": 1, "b": 2},
+        "null": None,
+    }
+
+    serialized = serializer.serialize(test_data)
+    assert isinstance(serialized, str)
+
+    # Verify it's base64 encoded
+    try:
+        base64.b64decode(serialized)
+    except Exception:
+        pytest.fail("Serialized data is not valid base64")
+
+    deserialized = serializer.deserialize(serialized)
+    assert deserialized == test_data
+
+
+@pytest.mark.parametrize(
+    "test_data",
+    [
+        {"string": "hello", "number": 42},
+        [1, 2, 3, 4, 5],
+        "simple string",
+        42,
+        True,
+        None,
+    ],
+)
+def test_serializer_chain(test_data: Any):
+    """Test that the default serializer chain can handle various data types"""
+    for serializer in DEFAULT_SERIALIZER_CHAIN:
+        serialized = serializer.serialize(test_data)
+        assert isinstance(serialized, str)
+
+        deserialized = serializer.deserialize(serialized)
+        assert deserialized == test_data
+
+
+# Test CloudPickleSerializer only if cloudpickle is available
+try:
+    importlib.util.find_spec("cloudpickle")
+
+    HAS_CLOUDPICKLE = True
+except ImportError:
+    HAS_CLOUDPICKLE = False  # pyright: ignore[reportConstantRedefinition]
+
+
+@pytest.mark.skipif(not HAS_CLOUDPICKLE, reason="cloudpickle not installed")
+def test_cloudpickle_serializer():
+    serializer = CloudPickleSerializer()
+
+    # Test with more complex Python objects
+    class TestClass:
+        def __init__(self, value: Any):
+            self.value = value
+
+        def __eq__(self, other: Any) -> bool:
+            return isinstance(other, TestClass) and self.value == other.value
+
+    test_data: dict[str, str | int | TestClass | Callable[[int], int]] = {
+        "string": "hello",
+        "number": 42,
+        "object": TestClass("test"),
+        "lambda": lambda x: x * 2,
+    }
+
+    serialized = serializer.serialize(test_data)
+    assert isinstance(serialized, str)
+
+    # Verify it's base64 encoded
+    try:
+        base64.b64decode(serialized)
+    except Exception:
+        pytest.fail("Serialized data is not valid base64")
+
+    deserialized = serializer.deserialize(serialized)
+    assert deserialized["string"] == test_data["string"]
+    assert deserialized["number"] == test_data["number"]
+    assert deserialized["object"] == test_data["object"]
+    assert deserialized["lambda"](5) == test_data["lambda"](5)  # pyright: ignore[reportCallIssue]
+
+
+@pytest.mark.skipif(HAS_CLOUDPICKLE, reason="cloudpickle is installed")
+def test_cloudpickle_serializer_import_error():
+    serializer = CloudPickleSerializer()
+
+    with pytest.raises(ImportError) as excinfo:
+        serializer.serialize({"test": "data"})
+
+    assert "Unable to import cloudpickle" in str(excinfo.value)
+    assert "install 'stickynote[cloudpickle]'" in str(excinfo.value)

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/39/069100b84d7418bc358d81669d5748efb14b9cceacd2f9c75f550424132f/cloudpickle-3.1.1.tar.gz", hash = "sha256:b216fa8ae4019d5482a8ac3c95d8f6346115d8835911fd4aefd1a445e4242c64", size = 22113 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl", hash = "sha256:c8c5a44295039331ee9dad40ba100a9c7297b6f988e50e87ccdf3765a668350e", size = 20992 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -147,6 +156,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-watcher"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/72/a2a1e81f1b272ddd9a1848af4959c87c39aa95c0bbfb3007cacb86c47fa9/pytest_watcher-0.4.3.tar.gz", hash = "sha256:0cb0e4661648c8c0ff2b2d25efa5a8e421784b9e4c60fcecbf9b7c30b2d731b3", size = 10386 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/3a/c44a76c6bb5e9e896d9707fb1c704a31a0136950dec9514373ced0684d56/pytest_watcher-0.4.3-py3-none-any.whl", hash = "sha256:d59b1e1396f33a65ea4949b713d6884637755d641646960056a90b267c3460f9", size = 11852 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -229,7 +251,14 @@ name = "stickynote"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "exceptiongroup" },
+    { name = "pytest-watcher" },
     { name = "typing-extensions" },
+]
+
+[package.optional-dependencies]
+cloudpickle = [
+    { name = "cloudpickle" },
 ]
 
 [package.dev-dependencies]
@@ -241,7 +270,12 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typing-extensions", specifier = ">=4.13.1" }]
+requires-dist = [
+    { name = "cloudpickle", marker = "extra == 'cloudpickle'", specifier = ">=3.1.1" },
+    { name = "exceptiongroup", specifier = ">=1.2.2" },
+    { name = "pytest-watcher", specifier = ">=0.4.3" },
+    { name = "typing-extensions", specifier = ">=4.13.1" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -311,4 +345,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/e0/633e369b91bbc664df47dcb5454b6c7cf441e8f5b9d0c250ce9f0546401e/virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8", size = 4346945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/ed/3cfeb48175f0671ec430ede81f628f9fb2b1084c9064ca67ebe8c0ed6a05/virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6", size = 4329461 },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390 },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389 },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020 },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393 },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392 },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019 },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471 },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449 },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054 },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480 },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451 },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057 },
+    { url = "https://files.pythonhosted.org/packages/05/52/7223011bb760fce8ddc53416beb65b83a3ea6d7d13738dde75eeb2c89679/watchdog-6.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e6f0e77c9417e7cd62af82529b10563db3423625c5fce018430b249bf977f9e8", size = 96390 },
+    { url = "https://files.pythonhosted.org/packages/9c/62/d2b21bc4e706d3a9d467561f487c2938cbd881c69f3808c43ac1ec242391/watchdog-6.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90c8e78f3b94014f7aaae121e6b909674df5b46ec24d6bebc45c44c56729af2a", size = 88386 },
+    { url = "https://files.pythonhosted.org/packages/ea/22/1c90b20eda9f4132e4603a26296108728a8bfe9584b006bd05dd94548853/watchdog-6.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c", size = 89017 },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902 },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380 },
+    { url = "https://files.pythonhosted.org/packages/5b/79/69f2b0e8d3f2afd462029031baafb1b75d11bb62703f0e1022b2e54d49ee/watchdog-6.0.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7a0e56874cfbc4b9b05c60c8a1926fedf56324bb08cfbc188969777940aef3aa", size = 87903 },
+    { url = "https://files.pythonhosted.org/packages/e2/2b/dc048dd71c2e5f0f7ebc04dd7912981ec45793a03c0dc462438e0591ba5d/watchdog-6.0.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e6439e374fc012255b4ec786ae3c4bc838cd7309a540e5fe0952d03687d8804e", size = 88381 },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
 ]


### PR DESCRIPTION
The provided serializer can be a single instance or a chain of serializer that will be attempted in order. The first serializer that succeeds is used.

- Add `JsonSerializer`, `PickleSerializer`, and `CloudPickleSerializer`
- Add `DEFAULT_SERIALIZER_CHAIN`
