### PR TITLE
Add ability to specify `on_cache_hit` callbacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,6 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "exceptiongroup>=1.2.2",
-    "freezegun>=1.5.1",
-    "pytest-watcher>=0.4.3",
     "typing-extensions>=4.13.1",
 ]
 
@@ -20,8 +18,10 @@ cloudpickle = ["cloudpickle>=3.1.1"]
 
 [dependency-groups]
 dev = [
+    "freezegun>=1.5.1",
     "pre-commit>=4.2.0",
     "pyright>=1.1.398",
     "pytest>=8.3.5",
+    "pytest-watcher>=0.4.3",
     "ruff>=0.11.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "exceptiongroup>=1.2.2",
+    "freezegun>=1.5.1",
     "pytest-watcher>=0.4.3",
     "typing-extensions>=4.13.1",
 ]

--- a/stickynote/__init__.py
+++ b/stickynote/__init__.py
@@ -1,3 +1,35 @@
 from .memoize import memoize
 
 __all__ = ["memoize"]
+
+"""
+StickyNote - A Python library for memoization with flexible storage backends.
+
+The main decorator is `memoize`, which can be used to cache the results of functions.
+It supports various storage backends, key strategies, and serializers.
+
+Example:
+    >>> from stickynote import memoize
+    >>> from stickynote.storage import MemoryStorage
+    >>> 
+    >>> # Basic usage
+    >>> @memoize
+    >>> def add(a, b):
+    >>>     return a + b
+    >>> 
+    >>> # With a custom storage backend
+    >>> storage = MemoryStorage()
+    >>> @memoize(storage=storage)
+    >>> def multiply(a, b):
+    >>>     return a * b
+    >>> 
+    >>> # With a cache hit callback
+    >>> cache_hit_count = 0
+    >>> def on_cache_hit():
+    >>>     nonlocal cache_hit_count
+    >>>     cache_hit_count += 1
+    >>> 
+    >>> @memoize(storage=storage, on_cache_hit=on_cache_hit)
+    >>> def subtract(a, b):
+    >>>     return a - b
+"""

--- a/stickynote/__init__.py
+++ b/stickynote/__init__.py
@@ -1,35 +1,3 @@
 from .memoize import memoize
 
 __all__ = ["memoize"]
-
-"""
-StickyNote - A Python library for memoization with flexible storage backends.
-
-The main decorator is `memoize`, which can be used to cache the results of functions.
-It supports various storage backends, key strategies, and serializers.
-
-Example:
-    >>> from stickynote import memoize
-    >>> from stickynote.storage import MemoryStorage
-    >>> 
-    >>> # Basic usage
-    >>> @memoize
-    >>> def add(a, b):
-    >>>     return a + b
-    >>> 
-    >>> # With a custom storage backend
-    >>> storage = MemoryStorage()
-    >>> @memoize(storage=storage)
-    >>> def multiply(a, b):
-    >>>     return a * b
-    >>> 
-    >>> # With a cache hit callback
-    >>> cache_hit_count = 0
-    >>> def on_cache_hit():
-    >>>     nonlocal cache_hit_count
-    >>>     cache_hit_count += 1
-    >>> 
-    >>> @memoize(storage=storage, on_cache_hit=on_cache_hit)
-    >>> def subtract(a, b):
-    >>>     return a - b
-"""

--- a/stickynote/memoize.py
+++ b/stickynote/memoize.py
@@ -102,10 +102,6 @@ def memoize(
     storage: MemoStorage = DEFAULT_STORAGE,
     key_strategy: MemoKeyStrategy = DEFAULT_STRATEGY,
     serializer: Serializer | Iterable[Serializer] = DEFAULT_SERIALIZER_CHAIN,
-    on_cache_hit: Callable[
-        [str, Any, Callable[..., Any], tuple[Any, ...], dict[str, Any], datetime], None
-    ]
-    | None = None,
 ) -> Callable[[Callable[P, R]], MemoizedCallable[P, R]]: ...
 
 
@@ -115,10 +111,6 @@ def memoize(
     storage: MemoStorage = DEFAULT_STORAGE,
     key_strategy: MemoKeyStrategy = DEFAULT_STRATEGY,
     serializer: Serializer | Iterable[Serializer] = DEFAULT_SERIALIZER_CHAIN,
-    on_cache_hit: Callable[
-        [str, R, Callable[..., R], tuple[Any, ...], dict[str, Any], datetime], None
-    ]
-    | None = None,
 ) -> Callable[[Callable[P, R]], MemoizedCallable[P, R]] | MemoizedCallable[P, R]:
     """
     Decorator to memoize the results of a function.
@@ -132,7 +124,6 @@ def memoize(
                 storage=storage,
                 key_strategy=key_strategy,
                 serializer=serializer,
-                on_cache_hit=on_cache_hit,
             ),
         )
     else:

--- a/stickynote/memoize.py
+++ b/stickynote/memoize.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import timezone, datetime
 from functools import partial
 from typing import (
     Any,
@@ -93,7 +93,7 @@ def memoize(
                             __fn,
                             args,
                             kwargs,
-                            datetime.now(UTC),
+                            datetime.now(timezone.utc),
                         )
                     return memo.value
                 result = __fn(*args, **kwargs)

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from datetime import UTC, datetime
+from datetime import timezone, datetime
 import pickle
 from typing import Any, Callable, Dict
 import importlib.util
@@ -398,7 +398,9 @@ class TestMemoize:
         memoized_add(1, 2)
         spy.assert_not_called()
         memoized_add(1, 2)
-        spy.assert_called_once_with("test_key", 3, add, (1, 2), {}, datetime.now(UTC))
+        spy.assert_called_once_with(
+            "test_key", 3, add, (1, 2), {}, datetime.now(timezone.utc)
+        )
 
 
 class TestMemoBlock:

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from datetime import timezone, datetime
 import pickle
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 import importlib.util
 from unittest.mock import MagicMock
 from freezegun import freeze_time
@@ -80,7 +80,7 @@ class TestMemoize:
         call_count = 0
 
         @memoize(storage=storage)
-        def create_dict(a: int, b: int) -> Dict[str, int]:
+        def create_dict(a: int, b: int) -> dict[str, int]:
             nonlocal call_count
             call_count += 1
             return {"sum": a + b, "product": a * b}
@@ -391,9 +391,9 @@ class TestMemoize:
         def add(a: int, b: int) -> int:
             return a + b
 
-        memoized_add = memoize(
-            storage=storage, on_cache_hit=spy, key_strategy=StaticKeyStrategy()
-        )(add)
+        memoized_add = memoize(storage=storage, key_strategy=StaticKeyStrategy())(add)
+
+        memoized_add.on_cache_hit(spy)
 
         memoized_add(1, 2)
         spy.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -285,8 +285,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "exceptiongroup" },
-    { name = "freezegun" },
-    { name = "pytest-watcher" },
     { name = "typing-extensions" },
 ]
 
@@ -297,9 +295,11 @@ cloudpickle = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "freezegun" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-watcher" },
     { name = "ruff" },
 ]
 
@@ -307,16 +307,16 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", marker = "extra == 'cloudpickle'", specifier = ">=3.1.1" },
     { name = "exceptiongroup", specifier = ">=1.2.2" },
-    { name = "freezegun", specifier = ">=1.5.1" },
-    { name = "pytest-watcher", specifier = ">=0.4.3" },
     { name = "typing-extensions", specifier = ">=4.13.1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "freezegun", specifier = ">=1.5.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pyright", specifier = ">=1.1.398" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-watcher", specifier = ">=0.4.3" },
     { name = "ruff", specifier = ">=0.11.4" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ef/722b8d71ddf4d48f25f6d78aa2533d505bf3eec000a7cacb8ccc8de61f2f/freezegun-1.5.1.tar.gz", hash = "sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9", size = 33697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/0b/0d7fee5919bccc1fdc1c2a7528b98f65c6f69b223a3fd8f809918c142c36/freezegun-1.5.1-py3-none-any.whl", hash = "sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1", size = 17569 },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.9"
 source = { registry = "https://pypi.org/simple" }
@@ -169,6 +181,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -247,11 +271,21 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
 name = "stickynote"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "exceptiongroup" },
+    { name = "freezegun" },
     { name = "pytest-watcher" },
     { name = "typing-extensions" },
 ]
@@ -273,6 +307,7 @@ dev = [
 requires-dist = [
     { name = "cloudpickle", marker = "extra == 'cloudpickle'", specifier = ">=3.1.1" },
     { name = "exceptiongroup", specifier = ">=1.2.2" },
+    { name = "freezegun", specifier = ">=1.5.1" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
     { name = "typing-extensions", specifier = ">=4.13.1" },
 ]


### PR DESCRIPTION
Usage:

```python
import sticknote


@stickynote.memoize
def add(a: int, b: int) -> int:
    return a + b


@add.on_cache_hit
def log_on_cache_hit(
    key: str,
    value: int,
    fn: Callable[[int, int], int],
    args: tuple[Any, ...],
    kwargs: dict[str, Any],
    timestamp: datetime,
):
    print("Cache hit!")

```