### PR TITLE
Add expiration support to Redis storage

### DIFF
--- a/stickynote/storage/redis.py
+++ b/stickynote/storage/redis.py
@@ -139,11 +139,11 @@ class RedisStorage(MemoStorage):
         """
         Get the value of a key from Redis.
         """
-        if not self._is_valid(key, max_age, created_after):
-            raise ExpiredMemoError(f"Memo for key {key} has expired in Redis")
         value = cast(Optional[str], self.client.get(self._key(key)))
         if value is None:
             raise MissingMemoError(f"Memo for key {key} not found in Redis")
+        if not self._is_valid(key, max_age, created_after):
+            raise ExpiredMemoError(f"Memo for key {key} has expired in Redis")
         return value
 
     async def get_async(
@@ -155,13 +155,13 @@ class RedisStorage(MemoStorage):
         """
         Get the value of a key from Redis.
         """
+        value = cast(Optional[str], await self.async_client.get(self._key(key)))
+        if value is None:
+            raise MissingMemoError(f"Memo for key {key} not found in Redis")
         if not await self._is_valid_async(key, max_age, created_after):
             raise ExpiredMemoError(
                 f"Memo for key {key} is not valid in the requested time window"
             )
-        value = cast(Optional[str], await self.async_client.get(self._key(key)))
-        if value is None:
-            raise MissingMemoError(f"Memo for key {key} not found in Redis")
         return value
 
     def set(self, key: str, value: str) -> None:

--- a/stickynote/storage/redis.py
+++ b/stickynote/storage/redis.py
@@ -143,7 +143,9 @@ class RedisStorage(MemoStorage):
         if value is None:
             raise MissingMemoError(f"Memo for key {key} not found in Redis")
         if not self._is_valid(key, max_age, created_after):
-            raise ExpiredMemoError(f"Memo for key {key} has expired in Redis")
+            raise ExpiredMemoError(
+                f"Memo for key {key} is not valid in the requested time window"
+            )
         return value
 
     async def get_async(

--- a/stickynote/storage/redis.py
+++ b/stickynote/storage/redis.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Optional, cast
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
-from .base import MemoStorage, MissingMemoError
+from .base import ExpiredMemoError, MemoStorage, MissingMemoError
 
 try:
     import redis
@@ -58,6 +58,52 @@ class RedisStorage(MemoStorage):
         """Add prefix to key."""
         return f"{self.prefix}{key}"
 
+    def _created_at_key(self, key: str) -> str:
+        """Add created_at to key."""
+        return f"{self.prefix}{key}:created_at"
+
+    def _is_valid(
+        self,
+        key: str,
+        max_age: timedelta | None = None,
+        created_after: datetime | None = None,
+    ) -> bool:
+        """Check if a key is valid according to expiration rules."""
+        created_at_timestamp = cast(
+            Union[str, None], self.client.get(self._created_at_key(key))
+        )
+        if created_at_timestamp is None:
+            return False
+        created_at = datetime.fromisoformat(created_at_timestamp)
+        if max_age is not None:
+            if (datetime.now(timezone.utc) - created_at) > max_age:
+                return False
+        if created_after is not None:
+            if created_at < created_after:
+                return False
+        return True
+
+    async def _is_valid_async(
+        self,
+        key: str,
+        max_age: timedelta | None = None,
+        created_after: datetime | None = None,
+    ) -> bool:
+        """Check if a key is valid according to expiration rules."""
+        created_at_timestamp = cast(
+            Union[str, None], await self.async_client.get(self._created_at_key(key))
+        )
+        if created_at_timestamp is None:
+            return False
+        created_at = datetime.fromisoformat(created_at_timestamp)
+        if max_age is not None:
+            if (datetime.now(timezone.utc) - created_at) > max_age:
+                return False
+        if created_after is not None:
+            if created_at < created_after:
+                return False
+        return True
+
     def exists(
         self,
         key: str,
@@ -67,11 +113,9 @@ class RedisStorage(MemoStorage):
         """
         Check if a key exists in Redis.
         """
-        if max_age is not None or created_after is not None:
-            raise NotImplementedError(
-                "max_age and created_after are not yet supported for Redis storage"
-            )
-        return bool(self.client.exists(self._key(key)))
+        return bool(self.client.exists(self._key(key))) and self._is_valid(
+            key, max_age, created_after
+        )
 
     async def exists_async(
         self,
@@ -82,11 +126,9 @@ class RedisStorage(MemoStorage):
         """
         Check if a key exists in Redis.
         """
-        if max_age is not None or created_after is not None:
-            raise NotImplementedError(
-                "max_age and created_after are not yet supported for Redis storage"
-            )
-        return bool(await self.async_client.exists(self._key(key)))
+        return bool(
+            await self.async_client.exists(self._key(key))
+        ) and await self._is_valid_async(key, max_age, created_after)
 
     def get(
         self,
@@ -97,10 +139,8 @@ class RedisStorage(MemoStorage):
         """
         Get the value of a key from Redis.
         """
-        if max_age is not None or created_after is not None:
-            raise NotImplementedError(
-                "max_age and created_after are not yet supported for Redis storage"
-            )
+        if not self._is_valid(key, max_age, created_after):
+            raise ExpiredMemoError(f"Memo for key {key} has expired in Redis")
         value = cast(Optional[str], self.client.get(self._key(key)))
         if value is None:
             raise MissingMemoError(f"Memo for key {key} not found in Redis")
@@ -115,9 +155,9 @@ class RedisStorage(MemoStorage):
         """
         Get the value of a key from Redis.
         """
-        if max_age is not None or created_after is not None:
-            raise NotImplementedError(
-                "max_age and created_after are not yet supported for Redis storage"
+        if not await self._is_valid_async(key, max_age, created_after):
+            raise ExpiredMemoError(
+                f"Memo for key {key} is not valid in the requested time window"
             )
         value = cast(Optional[str], await self.async_client.get(self._key(key)))
         if value is None:
@@ -128,10 +168,16 @@ class RedisStorage(MemoStorage):
         """
         Set the value of a key in Redis.
         """
-        self.client.set(self._key(key), value)
+        pipe = self.client.pipeline()  # pyright: ignore[reportUnknownMemberType]
+        pipe.set(self._key(key), value)
+        pipe.set(self._created_at_key(key), datetime.now(timezone.utc).isoformat())
+        pipe.execute()
 
     async def set_async(self, key: str, value: str) -> None:
         """
         Set the value of a key in Redis.
         """
-        await self.async_client.set(self._key(key), value)
+        pipe = self.async_client.pipeline()  # pyright: ignore[reportUnknownMemberType]
+        pipe.set(self._key(key), value)
+        pipe.set(self._created_at_key(key), datetime.now(timezone.utc).isoformat())
+        await pipe.execute()

--- a/tests/test_storage/test_redis.py
+++ b/tests/test_storage/test_redis.py
@@ -100,6 +100,12 @@ class TestRedisStorage:
         with pytest.raises(MissingMemoError):
             storage.get("nonexistent")
 
+    def test_get_with_missing_created_at(self, storage: RedisStorage):
+        key = "test-without-created-at"
+        storage.client.set(f"stickynote:{key}", "test")
+        with pytest.raises(ExpiredMemoError):
+            storage.get(key)
+
     async def test_get_async(self, storage: RedisStorage, existing_key: str):
         assert await storage.get_async(existing_key) == "test"
 
@@ -126,6 +132,12 @@ class TestRedisStorage:
     async def test_get_async_nonexistent(self, storage: RedisStorage):
         with pytest.raises(MissingMemoError):
             await storage.get_async("nonexistent")
+
+    async def test_get_async_with_missing_created_at(self, storage: RedisStorage):
+        key = "test-without-created-at-async"
+        await storage.async_client.set(f"stickynote:{key}", "test")
+        with pytest.raises(ExpiredMemoError):
+            await storage.get_async(key)
 
     def test_set(self, storage: RedisStorage):
         storage.set("test", "test")

--- a/tests/test_storage/test_redis.py
+++ b/tests/test_storage/test_redis.py
@@ -124,7 +124,7 @@ class TestRedisStorage:
             created_after=datetime.now(timezone.utc) - timedelta(seconds=10),
         )
         with pytest.raises(ExpiredMemoError):
-            assert await storage.get_async(
+            await storage.get_async(
                 existing_key,
                 created_after=datetime.now(timezone.utc) + timedelta(microseconds=1),
             )


### PR DESCRIPTION
Redis storage will store an additional key to track the creation time of the memo. That creation time is used to determine if a record is valid according to the provideded `max_age` and `created_after` parameters.
