### PR TITLE
Remove `max_age` from `Storage` Protocol

### DIFF
--- a/stickynote/storage/base.py
+++ b/stickynote/storage/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Protocol
 
 
@@ -24,7 +24,6 @@ class MemoStorage(Protocol):
     def exists(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> bool:
         """
@@ -32,7 +31,6 @@ class MemoStorage(Protocol):
 
         Args:
             key: The key to check
-            max_age: Maximum age of the record to be considered valid
             created_after: Only consider records created at or after this datetime
         """
         ...  # pragma: no cover
@@ -40,7 +38,6 @@ class MemoStorage(Protocol):
     async def exists_async(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> bool:
         """
@@ -48,7 +45,6 @@ class MemoStorage(Protocol):
 
         Args:
             key: The key to check
-            max_age: Maximum age of the record to be considered valid
             created_after: Only consider records created at or after this datetime
         """
         ...  # pragma: no cover
@@ -56,7 +52,6 @@ class MemoStorage(Protocol):
     def get(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> str:
         """
@@ -64,7 +59,6 @@ class MemoStorage(Protocol):
 
         Args:
             key: The key to retrieve
-            max_age: Maximum age of the record to be considered valid
             created_after: Only consider records created at or after this datetime
 
         Raises:
@@ -75,7 +69,6 @@ class MemoStorage(Protocol):
     async def get_async(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> str:
         """
@@ -83,7 +76,6 @@ class MemoStorage(Protocol):
 
         Args:
             key: The key to retrieve
-            max_age: Maximum age of the record to be considered valid
             created_after: Only consider records created at or after this datetime
 
         Raises:

--- a/stickynote/storage/memory.py
+++ b/stickynote/storage/memory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import TypedDict
 
 from .base import ExpiredMemoError, MemoStorage, MissingMemoError
@@ -19,16 +19,15 @@ class MemoryStorage(MemoStorage):
         self.cache: dict[str, str] = {}
         self.metadata: dict[str, MemoRecordMetadata] = {}
 
-    def _is_valid(
-        self, key: str, max_age: timedelta | None, created_after: datetime | None
-    ) -> bool:
-        """Check if a key is valid according to expiration rules."""
-        created_at = self.metadata[key]["created_at"]
-        now = datetime.now(timezone.utc)
+    def _is_valid(self, key: str, created_after: datetime | None) -> bool:
+        """
+        Check if a key is valid according to expiration rules.
 
-        # Check if too old
-        if max_age and (now - created_at) > max_age:
-            return False
+        Args:
+            key: The key to check
+            created_after: Only consider records created at or after this datetime
+        """
+        created_at = self.metadata[key]["created_at"]
 
         # Check if created before cutoff
         if created_after and created_at < created_after:
@@ -39,38 +38,47 @@ class MemoryStorage(MemoStorage):
     def exists(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> bool:
         """
         Check if a key exists in the cache and is valid according to expiration rules.
+
+        Args:
+            key: The key to check
+            created_after: Only consider records created at or after this datetime
         """
-        return key in self.cache and self._is_valid(key, max_age, created_after)
+        return key in self.cache and self._is_valid(key, created_after)
 
     async def exists_async(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> bool:
         """
         Check if a key exists in the cache and is valid according to expiration rules.
+
+        Args:
+            key: The key to check
+            created_after: Only consider records created at or after this datetime
         """
-        return key in self.cache and self._is_valid(key, max_age, created_after)
+        return key in self.cache and self._is_valid(key, created_after)
 
     def get(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> str:
         """
         Get the value of a key from the cache if it exists and is valid.
+
+        Args:
+            key: The key to get the value for
+            created_after: Only consider records created at or after this datetime
         """
         if key not in self.cache:
             raise MissingMemoError(f"Memo for key {key} not found in memory cache")
 
-        if not self._is_valid(key, max_age, created_after):
+        if not self._is_valid(key, created_after):
             raise ExpiredMemoError(
                 f"Memo for key {key} was created outside the requested time window"
             )
@@ -80,16 +88,19 @@ class MemoryStorage(MemoStorage):
     async def get_async(
         self,
         key: str,
-        max_age: timedelta | None = None,
         created_after: datetime | None = None,
     ) -> str:
         """
         Get the value of a key from the cache if it exists and is valid.
+
+        Args:
+            key: The key to get the value for
+            created_after: Only consider records created at or after this datetime
         """
         if key not in self.cache:
             raise MissingMemoError(f"Memo for key {key} not found in memory cache")
 
-        if not self._is_valid(key, max_age, created_after):
+        if not self._is_valid(key, created_after):
             raise ExpiredMemoError(
                 f"Memo for key {key} was created outside the requested time window"
             )
@@ -99,6 +110,10 @@ class MemoryStorage(MemoStorage):
     def set(self, key: str, value: str) -> None:
         """
         Set the value of a key in the cache with current timestamp.
+
+        Args:
+            key: The key to set the value for
+            value: The value to set
         """
         self.cache[key] = value
         self.metadata[key] = {"created_at": datetime.now(timezone.utc)}
@@ -106,6 +121,10 @@ class MemoryStorage(MemoStorage):
     async def set_async(self, key: str, value: str) -> None:
         """
         Set the value of a key in the cache with current timestamp.
+
+        Args:
+            key: The key to set the value for
+            value: The value to set
         """
         self.cache[key] = value
         self.metadata[key] = {"created_at": datetime.now(timezone.utc)}

--- a/tests/test_storage/test_file.py
+++ b/tests/test_storage/test_file.py
@@ -31,10 +31,6 @@ class TestFileStorage:
     def test_exists_nonexistent(self, storage: FileStorage):
         assert not storage.exists("test")
 
-    def test_exists_with_max_age(self, storage: FileStorage, existing_file: Path):
-        assert storage.exists(existing_file.name, max_age=timedelta(seconds=10))
-        assert not storage.exists(existing_file.name, max_age=timedelta(microseconds=1))
-
     def test_exists_with_created_after(self, storage: FileStorage, existing_file: Path):
         assert storage.exists(
             existing_file.name,
@@ -47,16 +43,6 @@ class TestFileStorage:
 
     async def test_exists_async(self, storage: FileStorage, existing_file: Path):
         assert await storage.exists_async(existing_file.name)
-
-    async def test_exists_async_with_max_age(
-        self, storage: FileStorage, existing_file: Path
-    ):
-        assert await storage.exists_async(
-            existing_file.name, max_age=timedelta(seconds=10)
-        )
-        assert not await storage.exists_async(
-            existing_file.name, max_age=timedelta(microseconds=1)
-        )
 
     async def test_exists_async_with_created_after(
         self, storage: FileStorage, existing_file: Path
@@ -80,11 +66,6 @@ class TestFileStorage:
         with pytest.raises(MissingMemoError):
             storage.get("test")
 
-    def test_get_with_max_age(self, storage: FileStorage, existing_file: Path):
-        assert storage.get(existing_file.name, max_age=timedelta(seconds=10)) == "test"
-        with pytest.raises(ExpiredMemoError):
-            storage.get(existing_file.name, max_age=timedelta(microseconds=1))
-
     def test_get_with_created_after(self, storage: FileStorage, existing_file: Path):
         assert storage.get(
             existing_file.name,
@@ -98,18 +79,6 @@ class TestFileStorage:
 
     async def test_get_async(self, storage: FileStorage, existing_file: Path):
         assert await storage.get_async(existing_file.name) == "test"
-
-    async def test_get_async_with_max_age(
-        self, storage: FileStorage, existing_file: Path
-    ):
-        assert (
-            await storage.get_async(existing_file.name, max_age=timedelta(seconds=10))
-            == "test"
-        )
-        with pytest.raises(ExpiredMemoError):
-            await storage.get_async(
-                existing_file.name, max_age=timedelta(microseconds=1)
-            )
 
     async def test_get_async_with_created_after(
         self, storage: FileStorage, existing_file: Path

--- a/tests/test_storage/test_memory.py
+++ b/tests/test_storage/test_memory.py
@@ -19,11 +19,6 @@ class TestMemoryStorage:
     def test_exists(self, storage: MemoryStorage, existing_key: str):
         assert storage.exists(existing_key)
 
-    def test_exists_with_max_age(self, storage: MemoryStorage, existing_key: str):
-        assert storage.exists(existing_key, max_age=timedelta(seconds=10))
-        # a valid record isn't found because the existing one is more than 1 microsecond old
-        assert not storage.exists(existing_key, max_age=timedelta(microseconds=1))
-
     def test_exists_with_created_after(self, storage: MemoryStorage, existing_key: str):
         assert storage.exists(
             existing_key,
@@ -36,14 +31,6 @@ class TestMemoryStorage:
 
     async def test_exists_async(self, storage: MemoryStorage):
         assert not await storage.exists_async("test")
-
-    async def test_exists_async_with_max_age(
-        self, storage: MemoryStorage, existing_key: str
-    ):
-        assert await storage.exists_async(existing_key, max_age=timedelta(seconds=10))
-        assert not await storage.exists_async(
-            existing_key, max_age=timedelta(microseconds=1)
-        )
 
     async def test_exists_async_with_created_after(
         self, storage: MemoryStorage, existing_key: str
@@ -66,11 +53,6 @@ class TestMemoryStorage:
     def test_get(self, storage: MemoryStorage, existing_key: str):
         assert storage.get(existing_key) == "test"
 
-    def test_get_with_max_age(self, storage: MemoryStorage, existing_key: str):
-        assert storage.get(existing_key, max_age=timedelta(seconds=10)) == "test"
-        with pytest.raises(ExpiredMemoError):
-            storage.get(existing_key, max_age=timedelta(microseconds=1))
-
     def test_get_with_created_after(self, storage: MemoryStorage, existing_key: str):
         assert (
             storage.get(
@@ -87,16 +69,6 @@ class TestMemoryStorage:
 
     async def test_get_async(self, storage: MemoryStorage, existing_key: str):
         assert await storage.get_async(existing_key) == "test"
-
-    async def test_get_async_with_max_age(
-        self, storage: MemoryStorage, existing_key: str
-    ):
-        assert (
-            await storage.get_async(existing_key, max_age=timedelta(seconds=10))
-            == "test"
-        )
-        with pytest.raises(ExpiredMemoError):
-            await storage.get_async(existing_key, max_age=timedelta(microseconds=1))
 
     async def test_get_async_with_created_after(
         self, storage: MemoryStorage, existing_key: str

--- a/tests/test_storage/test_redis.py
+++ b/tests/test_storage/test_redis.py
@@ -37,10 +37,6 @@ class TestRedisStorage:
     def test_exists_nonexistent(self, storage: RedisStorage):
         assert not storage.exists("nonexistent")
 
-    def test_exists_with_max_age(self, storage: RedisStorage, existing_key: str):
-        assert storage.exists(existing_key, max_age=timedelta(seconds=10))
-        assert not storage.exists(existing_key, max_age=timedelta(microseconds=1))
-
     def test_exists_with_created_after(self, storage: RedisStorage, existing_key: str):
         assert storage.exists(
             existing_key,
@@ -53,14 +49,6 @@ class TestRedisStorage:
 
     async def test_exists_async(self, storage: RedisStorage, existing_key: str):
         assert await storage.exists_async(existing_key)
-
-    async def test_exists_async_with_max_age(
-        self, storage: RedisStorage, existing_key: str
-    ):
-        assert await storage.exists_async(existing_key, max_age=timedelta(seconds=10))
-        assert not await storage.exists_async(
-            existing_key, max_age=timedelta(microseconds=1)
-        )
 
     async def test_exists_async_with_created_after(
         self, storage: RedisStorage, existing_key: str
@@ -79,11 +67,6 @@ class TestRedisStorage:
 
     def test_get(self, storage: RedisStorage, existing_key: str):
         assert storage.get(existing_key) == "test"
-
-    def test_get_with_max_age(self, storage: RedisStorage, existing_key: str):
-        assert storage.get(existing_key, max_age=timedelta(seconds=10))
-        with pytest.raises(ExpiredMemoError):
-            storage.get(existing_key, max_age=timedelta(microseconds=1))
 
     def test_get_with_created_after(self, storage: RedisStorage, existing_key: str):
         assert storage.get(
@@ -108,13 +91,6 @@ class TestRedisStorage:
 
     async def test_get_async(self, storage: RedisStorage, existing_key: str):
         assert await storage.get_async(existing_key) == "test"
-
-    async def test_get_async_with_max_age(
-        self, storage: RedisStorage, existing_key: str
-    ):
-        assert await storage.get_async(existing_key, max_age=timedelta(seconds=10))
-        with pytest.raises(ExpiredMemoError):
-            await storage.get_async(existing_key, max_age=timedelta(microseconds=1))
 
     async def test_get_async_with_created_after(
         self, storage: RedisStorage, existing_key: str


### PR DESCRIPTION
`max_age` and `created_after` are redundant, so `max_age` I've removed it from the `Storage` protocol. The `@memoize` decorator will still be able to use `datetime` and `timedelta` inputs, but it's easier to accept just one type at this level.
